### PR TITLE
cambiando de titulo para no confundir

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@ null
               
                   <!-- Github -->
                   <li class="social item hvr-grow-rotate">
-                    <a rel="me" href="http://pixiv.me/meu_key" title="Pinterest account">
+                    <a rel="me" href="http://pixiv.me/meu_key" title="Pixiv account">
                       <i class='icon icon-social-pinterest'></i>
                       <span class="label">Pinterest</span>
                     </a>


### PR DESCRIPTION
el icono decía que iba a una cuenta de pinterest pero yo no tengo una cuenta allí y el enlace dirige a otro sitio, solo faltaría cambiar el icono de la cuenta y ya esta también debería agregar la cuenta de tumblr en otra parte